### PR TITLE
Added documentation link to GitHub Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Movecraft
 
 Movecraft 3 is the premier movement plugin for bukkit.
 
-Source hosted on GitHub, Localisation on gettranslation.com and Documentation on readtthedocs.org
+Source hosted on GitHub, Localisation on gettranslation.com and Documentation on Github https://github.com/msummers123/Movecraft-3/wiki
 
 This repository is built by Jenkins CI provided by cloudbees PaaS
 


### PR DESCRIPTION
I am re-writing the entire Documentation into the Movecraft github Wiki for better and easier understanding, added the link to the main readme. - GodsDead
