### PR TITLE
added option specify offset for Subcraft Rotation 

### DIFF
--- a/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -36,6 +36,7 @@ import java.util.List;
 import org.bukkit.Material;
 
 import java.util.logging.Level;
+import net.countercraft.movecraft.utils.MovecraftLocation;
 
 public class CraftType {
 	private String craftName;
@@ -65,6 +66,7 @@ public class CraftType {
 	private int hoverLimit;
 	private List<Material> harvestBlocks;
         private List<Material> harvesterBladeBlocks;
+        private MovecraftLocation maxRotateOffset = new MovecraftLocation(0, 0, 0);
 	        
 	public CraftType( File f ) {
 		try {
@@ -432,6 +434,21 @@ public class CraftType {
             }else{
                 allowVerticalTakeoffAndLanding = true;
             }
+            if (data.containsKey("maxRotateOffset")){
+              HashMap<Object, Object> tmpMaxRotateOffset =(HashMap<Object, Object>) data.get("maxRotateOffset");
+              for(Object i : tmpMaxRotateOffset.keySet()) {
+                if(i instanceof String) {
+                  String str=(String)i;  
+                  if(str.equalsIgnoreCase("x")) {
+                    maxRotateOffset.setX(integerFromObject(tmpMaxRotateOffset.get(i))); 
+                  }else if(str.equalsIgnoreCase("y")) {
+                    maxRotateOffset.setY(integerFromObject(tmpMaxRotateOffset.get(i))); 
+                  }else if(str.equalsIgnoreCase("z")) {
+                    maxRotateOffset.setZ(integerFromObject(tmpMaxRotateOffset.get(i))); 
+                  }
+                } 
+              }
+            }
 	}
 
 	public String getCraftName() {
@@ -617,5 +634,8 @@ public class CraftType {
     
     public boolean  allowVerticalTakeoffAndLanding(){
         return allowVerticalTakeoffAndLanding;
+    }
+    public MovecraftLocation getMaxRotateOffset(){
+      return maxRotateOffset;
     }
 }

--- a/src/main/java/net/countercraft/movecraft/utils/MovecraftLocation.java
+++ b/src/main/java/net/countercraft/movecraft/utils/MovecraftLocation.java
@@ -94,5 +94,22 @@ public class MovecraftLocation {
 	public MovecraftLocation subtract( MovecraftLocation l ) {
 		return new MovecraftLocation( getX() - l.getX(), getY() - l.getY(), getZ() - l.getZ() );
 	}
-
+        
+        public static MovecraftLocation getMLocationFromString(String str){
+          MovecraftLocation mLoc = new MovecraftLocation(0, 0, 0);
+          str = org.bukkit.ChatColor.stripColor(str);
+          if (str.indexOf(",") <= 0){
+            return mLoc;
+          }
+          String[] numbers = str.split(",");
+          mLoc.setX(Integer.parseInt(numbers[0].trim()));
+          if (numbers.length == 2){
+            mLoc.setZ(Integer.parseInt(numbers[1].trim()));
+          }
+          if (numbers.length == 3){
+            mLoc.setY(Integer.parseInt(numbers[1].trim()));
+            mLoc.setZ(Integer.parseInt(numbers[2].trim()));
+          }
+          return mLoc;
+        }
 }

--- a/src/main/java/net/countercraft/movecraft/utils/SignUtils.java
+++ b/src/main/java/net/countercraft/movecraft/utils/SignUtils.java
@@ -1,0 +1,18 @@
+package net.countercraft.movecraft.utils;
+
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Sign;
+import org.bukkit.material.MaterialData;
+
+public class SignUtils {
+  /**
+   * 
+   * @param sign
+   * @return 
+   */
+  public static BlockFace getFacing(Sign sign) {
+    MaterialData materialData = sign.getData();
+    org.bukkit.material.Sign matSign = (org.bukkit.material.Sign)materialData;
+    return matSign.getFacing();
+  }
+}


### PR DESCRIPTION
(improves maneuverability without leaving helm position)

Sign format:

1. Subcraft Rotate
2. craft_name
3. {empty row}
4. x,y,z

new coords are validated with maxRotateOffset and calculated by sign facing
-x = left,   +x = right, -y = bottom, +y = up, -z = backward, +z forward

new optional CraftType property with default values: 

maxRotateOffset:
  x: 0
  y: 0
  z: 0

if one of maxRotateOffset values is smaller than absolute value from the sign, it's used 0,0,0 instead of the value from the sign