### PR TITLE
Autofill blank pilot signs

### DIFF
--- a/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -246,6 +246,13 @@ public class BlockListener implements Listener {
 //				event.setCancelled(true);
 			}
         }
+        
+        if(signText.equalsIgnoreCase( "Pilot:")) {
+            String crewName=org.bukkit.ChatColor.stripColor(event.getLine(1));
+        	if(p.getName().isEmpty) {
+				event.setLine(1, p.getName());
+		}
+        }
     }
 	
 	@EventHandler(priority = EventPriority.LOW)


### PR DESCRIPTION
A pilot signs who's first line is blank will now be automatically filled in with the user's username, similar to the functionality of a Crew sign. This will allow players who have issues with pilot signs because of name changes or other reasons to place them with no hassle.