### PR TITLE
Unmerge command!

### DIFF
--- a/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -66,7 +66,7 @@ import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
 
 public class BlockListener implements Listener {
-	public static List<Block> unmergeBlocks;
+	public static List<BlockState> unmergeBlockStates;
 	
 	@EventHandler
 	public void onBlockPlace( final BlockPlaceEvent e ) {
@@ -150,12 +150,12 @@ public class BlockListener implements Listener {
 		// If unmerging log the bock, and place bedrock at its old location.
 		if (CommandListener.unmerging) {
 			// Add the broken block to the array
-			Block brokenBlock =  e.getBlock()
-			if (!unmergeBlocks) {
-				unmergeBlocks = new ArrayList<Block>();
+			BlockState brokenBlockState =  e.getBlock().getState();
+			if (!unmergeBlockStates) {
+				unmergeBlockStates = new ArrayList<BlockState>();
 			}
 			
-			unmergeBlocks.add(brokenBlock);
+			unmergeBlockStates.add(brokenBlockState);
 			
 			// Set a bedrock at its location
 			e.getBlock().setType(Material.BEDROCK);

--- a/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -66,7 +66,8 @@ import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.DefaultFlag;
 
 public class BlockListener implements Listener {
-
+	public static List<Block> unmergeBlocks;
+	
 	@EventHandler
 	public void onBlockPlace( final BlockPlaceEvent e ) {
 		if ( Settings.DisableCrates==true )
@@ -144,6 +145,20 @@ public class BlockListener implements Listener {
 			e.setCancelled( true );
 			e.getBlock().setType( Material.AIR );
 			e.getBlock().getLocation().getWorld().dropItemNaturally( e.getBlock().getLocation(), new StorageChestItem().getItemStack() );
+		}
+		
+		// If unmerging log the bock, and place bedrock at its old location.
+		if (CommandListener.unmerging) {
+			// Add the broken block to the array
+			Block brokenBlock =  e.getBlock()
+			if (!unmergeBlocks) {
+				unmergeBlocks = new ArrayList<Block>();
+			}
+			
+			unmergeBlocks.add(brokenBlock);
+			
+			// Set a bedrock at its location
+			e.getBlock().setType(Material.BEDROCK);
 		}
 	}
 

--- a/src/main/java/net/countercraft/movecraft/listener/CommandListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/CommandListener.java
@@ -528,7 +528,7 @@ public class CommandListener implements CommandExecutor {
 				
 			} else {
 				// Add permission to break any block.
-				unmergeAttachment = player.addAttachment(plugin, "node", yes);
+				unmergeAttachment = player.addAttachment(this, "worldguard.build.block.remove.*", yes, 6000);
 				
 				// Toggle unmerging bool
 				unmerging = true;

--- a/src/main/java/net/countercraft/movecraft/listener/CommandListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/CommandListener.java
@@ -54,7 +54,8 @@ import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 //public class CommandListener implements Listener {
 public class CommandListener implements CommandExecutor {
 	public static boolean unmerging = false;
-
+	public static PermissionAttachment unmergeAttachment;
+	
 	private CraftType getCraftTypeFromString( String s ) {
 		for ( CraftType t : CraftManager.getInstance().getCraftTypes() ) {
 			if ( s.equalsIgnoreCase( t.getCraftName() ) ) {
@@ -512,7 +513,8 @@ public class CommandListener implements CommandExecutor {
 		if (cmd.getName().equalsIgnoreCase("unmerge")) {
 			if (unmerging) {
 				// Remove permission to break any block.
-				
+				player.removeAttachment(unmergeAttachment);
+
 				// Toggle unmerging bool
 				unmerging = false;
 				
@@ -521,8 +523,12 @@ public class CommandListener implements CommandExecutor {
 					blockStateToBeRestored.update();
 				}
 				
+				// Clear the array
+				BlockListener.unmergeBlockStates = new ArrayList<BlockState>();
+				
 			} else {
 				// Add permission to break any block.
+				unmergeAttachment = player.addAttachment(plugin, "node", yes);
 				
 				// Toggle unmerging bool
 				unmerging = true;

--- a/src/main/java/net/countercraft/movecraft/listener/CommandListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/CommandListener.java
@@ -53,6 +53,7 @@ import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
 //public class CommandListener implements Listener {
 public class CommandListener implements CommandExecutor {
+	public static boolean unmerging = false;
 
 	private CraftType getCraftTypeFromString( String s ) {
 		for ( CraftType t : CraftManager.getInstance().getCraftTypes() ) {
@@ -380,7 +381,7 @@ public class CommandListener implements CommandExecutor {
 				
 		}
 		
-		if(cmd.getName().equalsIgnoreCase("manOverBoard")) {
+		if(cmd.getName().equalsIgnoreCase("manoverboard")) {
 			if(CraftManager.getInstance().getCraftByPlayerName(player.getName())!=null) {
 				Location telPoint = getCraftTeleportPoint(CraftManager.getInstance().getCraftByPlayerName(player.getName()), CraftManager.getInstance().getCraftByPlayerName(player.getName()).getW());
 				player.teleport(telPoint);
@@ -506,6 +507,26 @@ public class CommandListener implements CommandExecutor {
 				player.sendMessage( String.format( I18nSupport.getInternationalisedString( "Could not find a siege configuration for the region you are in" ) ) );
 				return true;
             }
+		}
+		
+		if (cmd.getName().equalsIgnoreCase("unmerge")) {
+			if (unmerging) {
+				// Remove permission to break any block.
+				
+				// Toggle unmerging bool
+				unmerging = false;
+				
+				// Restore blocks broken
+				for (BlockState blockStateToBeRestored : BlockListener.unmergeBlockStates) {
+					blockStateToBeRestored.update();
+				}
+				
+			} else {
+				// Add permission to break any block.
+				
+				// Toggle unmerging bool
+				unmerging = true;
+			}
 		}
 		
 		return false;

--- a/src/main/java/net/countercraft/movecraft/listener/InteractListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/InteractListener.java
@@ -292,6 +292,23 @@ public class InteractListener implements Listener {
 				}
 				
 				event.setCancelled( true );
+				
+				// Disbale merging state
+				if (CommandListener.unmerging) {
+					// Remove permission to break any block.
+					event.getPlayer().removeAttachment(CommandListener.unmergeAttachment);
+
+					// Toggle unmerging bool
+					CommandListener.unmerging = false;
+				
+					// Restore blocks broken
+					for (BlockState blockStateToBeRestored : BlockListener.unmergeBlockStates) {
+						blockStateToBeRestored.update();
+					}
+				
+					// Clear the array
+					BlockListener.unmergeBlockStates = new ArrayList<BlockState>();
+				}
 			} else {
 			event.getPlayer().sendMessage( String.format( I18nSupport.getInternationalisedString( "Insufficient Permissions" ) ) );
 

--- a/src/main/java/net/countercraft/movecraft/listener/PlayerListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/PlayerListener.java
@@ -168,6 +168,24 @@ public class PlayerListener implements Listener {
 		if ( c != null ) {
 			CraftManager.getInstance().removeCraft( c );
 		}
+		
+		// Disable unmerging mode
+		if (CommandListener.unmerging) {
+			// Remove permission to break any block.
+			player.removeAttachment(CommandListener.unmergeAttachment);
+
+			// Toggle unmerging bool			
+			CommandListener.unmerging = false;
+			
+			// Restore blocks broken
+			for (BlockState blockStateToBeRestored : BlockListener.unmergeBlockStates) {
+				blockStateToBeRestored.update();
+			}
+				
+			// Clear the array
+			BlockListener.unmergeBlockStates = new ArrayList<BlockState>();
+				
+		}
 	}
 
 /*	public void onPlayerDamaged( EntityDamageByEntityEvent e ) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -38,3 +38,6 @@ commands:
   siege:
     description: If the region you are standing in is configured for Siege, lays siege to it
     usage: /siege
+  unmerge:
+    description: Puts you in unmerge mode
+    usage: /unmerge


### PR DESCRIPTION
Unmerge command allows the user to do ./unmerge. In that mode a user can break any blocks even in protected airspace, broken blocks are immediately replaced with bedrock that cannot be broken. This allows the player to unmerge his ship. Once the user either pilots his ship, delays 5 minutes or does ./unmerge again, the bedrock are restored back to the original blocks, and the permission removed.

WARNING: This command uses WG permissions to enable users to break blocks in protected areas. These blocks will be restored later, and are meanwhile placed by bedrock. Please consider this functionality before enabling this command.