### PR TITLE
Add restricted sign strings

### DIFF
--- a/src/main/java/net/countercraft/movecraft/async/detection/DetectionTask.java
+++ b/src/main/java/net/countercraft/movecraft/async/detection/DetectionTask.java
@@ -72,12 +72,12 @@ public class DetectionTask extends AsyncTask {
         TownyWorld townyWorld = null;
         TownyWorldHeightLimits townyWorldHeightLimits = null;
         
-	public DetectionTask( Craft c, MovecraftLocation startLocation, int minSize, int maxSize, Integer[] allowedBlocks, Integer[] forbiddenBlocks, Player player, Player notificationPlayer, World w ) {
+	public DetectionTask( Craft c, MovecraftLocation startLocation, int minSize, int maxSize, Integer[] allowedBlocks, Integer[] forbiddenBlocks, String[] forbiddenSignStrings, Player player, Player notificationPlayer, World w ) {
 		super( c );
 		this.startLocation = startLocation;
 		this.minSize = minSize;
 		this.maxSize = maxSize;
-		data = new DetectionTaskData( w, player, notificationPlayer, allowedBlocks, forbiddenBlocks );
+		data = new DetectionTaskData( w, player, notificationPlayer, allowedBlocks, forbiddenBlocks, forbiddenSignStrings );
                 
                 this.townyEnabled = Movecraft.getInstance().getTownyPlugin() != null;
                 if (townyEnabled && Settings.TownyBlockMoveOnSwitchPerm){
@@ -143,6 +143,13 @@ public class DetectionTask extends AsyncTask {
 				BlockState state=data.getWorld().getBlockAt(x, y, z).getState();
 				if(state instanceof Sign) {
 					Sign s=(Sign)state;
+					for(int i=0;i<=4;i++)
+					{
+						if( isForbiddenSignString( getLine(i) ) ){
+							fail( String.format( I18nSupport.getInternationalisedString( "Detection - Forbidden sign string found" ) ) )
+							
+						}
+					}
 					if(s.getLine(0).equalsIgnoreCase("Pilot:") && data.getPlayer()!=null) {
 						String playerName=data.getPlayer().getName();
 						boolean foundPilot=false;
@@ -307,7 +314,18 @@ public class DetectionTask extends AsyncTask {
 
 		return false;
 	}
-
+	
+	private boolean isForbiddenSignString(Sting testString){
+		
+		for(String s : data.getForbiddenSignStrings() ){
+			if( testString.equals(s) ) {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+	
 	public DetectionTaskData getData() {
 		return data;
 	}

--- a/src/main/java/net/countercraft/movecraft/async/detection/DetectionTask.java
+++ b/src/main/java/net/countercraft/movecraft/async/detection/DetectionTask.java
@@ -318,7 +318,7 @@ public class DetectionTask extends AsyncTask {
 	private boolean isForbiddenSignString(Sting testString){
 		
 		for(String s : data.getForbiddenSignStrings() ){
-			if( testString.equals(s) ) {
+			if( testString.equals(ChatColor.stripColor(s)) ) {
 				return true;
 			}
 		}

--- a/src/main/java/net/countercraft/movecraft/async/detection/DetectionTaskData.java
+++ b/src/main/java/net/countercraft/movecraft/async/detection/DetectionTaskData.java
@@ -33,13 +33,15 @@ public class DetectionTaskData {
 	private int[][][] hitBox;
 	private Integer minX, minZ;
 	private Integer[] allowedBlocks, forbiddenBlocks;
+	private String[] forbiddenSignStrings;
 
-	public DetectionTaskData( World w, Player player, Player notificationPlayer, Integer[] allowedBlocks, Integer[] forbiddenBlocks ) {
+	public DetectionTaskData( World w, Player player, Player notificationPlayer, Integer[] allowedBlocks, Integer[] forbiddenBlocks, String[] forbiddenSignStrings) {
 		this.w = w;
 		this.player = player;
 		this.notificationPlayer = notificationPlayer;
 		this.allowedBlocks = allowedBlocks;
 		this.forbiddenBlocks = forbiddenBlocks;
+		this.forbiddenSignStrings = forbiddenSignStrings;
 		this.waterContact = false;
 	}
 
@@ -52,6 +54,10 @@ public class DetectionTaskData {
 
 	public Integer[] getForbiddenBlocks() {
 		return forbiddenBlocks;
+	}
+	
+	public Integer[] getForbiddenSignStrings() {
+		return forbiddenSignStrings;
 	}
 
 	public World getWorld() {

--- a/src/main/java/net/countercraft/movecraft/craft/Craft.java
+++ b/src/main/java/net/countercraft/movecraft/craft/Craft.java
@@ -109,7 +109,7 @@ public class Craft {
 	}
 
 	public void detect( Player player, Player notificationPlayer, MovecraftLocation startPoint ) {
-		AsyncManager.getInstance().submitTask( new DetectionTask( this, startPoint, type.getMinSize(), type.getMaxSize(), type.getAllowedBlocks(), type.getForbiddenBlocks(), player, notificationPlayer, w ), this );
+		AsyncManager.getInstance().submitTask( new DetectionTask( this, startPoint, type.getMinSize(), type.getMaxSize(), type.getAllowedBlocks(), type.getForbiddenBlocks(), type.getForbiddenSignStrings(), player, notificationPlayer, w ), this );
 	}
 
 	public void translate( int dx, int dy, int dz ) {

--- a/src/main/java/net/countercraft/movecraft/craft/CraftType.java
+++ b/src/main/java/net/countercraft/movecraft/craft/CraftType.java
@@ -41,6 +41,7 @@ public class CraftType {
 	private String craftName;
 	private int maxSize, minSize, minHeightLimit, maxHeightLimit, maxHeightAboveGround;
 	private Integer[] allowedBlocks, forbiddenBlocks;
+	private String[] forbiddenSignStrings;
 	private boolean blockedByWater, requireWaterContact, tryNudge, canCruise, canTeleport, canStaticMove, canHover, canDirectControl, useGravity, canHoverOverWater, moveEntities;
 	private boolean allowHorizontalMovement, allowVerticalMovement, allowRemoteSign, cruiseOnPilot, allowVerticalTakeoffAndLanding, rotateAtMidpoint;
 	private int cruiseOnPilotVertMove;
@@ -110,6 +111,18 @@ public class CraftType {
 			}
 		}
 		return returnList.toArray(new Integer[1]);
+	}
+	
+	private String[] stringListFromObject(Object obj) {
+		ArrayList<String> returnList=new ArrayList<String>();
+		ArrayList objList=(ArrayList) obj;
+		for(Object i : objList) {
+			if(i instanceof String) {
+				String str=(String)i;
+				returnList.add(str);
+			}
+		}
+		return returnList.toArray(new String[1]);
 	}
 
 	private HashMap<ArrayList<Integer>, ArrayList<Double>> blockIDMapListFromObject(Object obj) {
@@ -194,6 +207,7 @@ public class CraftType {
 		Arrays.sort(allowedBlocks);
 		
 		forbiddenBlocks = blockIDListFromObject(data.get( "forbiddenBlocks" ));
+		forbiddenSignStrings = stringListFromObject(data.get( "forbiddenSignStrings" ));
 		if(data.containsKey("canFly")) {
 			blockedByWater = ( Boolean ) data.get( "canFly" );
 		} else if (data.containsKey("blockedByWater")) {
@@ -452,6 +466,10 @@ public class CraftType {
 
 	public Integer[] getForbiddenBlocks() {
 		return forbiddenBlocks;
+	}
+
+	public String[] getForbiddenSignStrings() {
+		return forbiddenSignStrings;
 	}
 
 	public boolean blockedByWater() {


### PR DESCRIPTION
This is intended to add the possibility to restrict the text on signs on ships. This can be used to do things such as:
- stoping chests from being privated on ships
- stoping ceratin cannons from a cannon plugin from being on a ship
- prevent moving chest shops