### PR TITLE
/manoverboard teleport location was a little off

### DIFF
--- a/src/main/java/net/countercraft/movecraft/listener/CommandListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/CommandListener.java
@@ -110,9 +110,9 @@ public class CommandListener implements CommandExecutor {
 
 			}
 		}
-		int telX=craft.getMinX()+(maxDX / 2);
-		int telZ=craft.getMinZ()+(maxDZ / 2);
-		int telY=maxY;
+		double telX=craft.getMinX()+(maxDX / 2.0);
+		double telZ=craft.getMinZ()+(maxDZ / 2.0);
+		double telY=maxY + 1.0;
 		Location telPoint=new Location(w, telX, telY, telZ);
 		return telPoint;
 	}


### PR DESCRIPTION
If you try to /manoverboard to a 3x3x2 o 4x4 o 5x5 elevators with the elevator sign on the side, you'll see that you don't land exactly in the middle and you appear inside the floor.

With this patch, you always land in the exact middle (the block of the middle of an odd-sided square or between the two blocks in the middle of an even-sided square) and one block over the max Y of the craft.
