### PR TITLE
Allow extra chests in exchange for unused dispensers.

### DIFF
--- a/src/main/java/net/countercraft/movecraft/Movecraft.java
+++ b/src/main/java/net/countercraft/movecraft/Movecraft.java
@@ -204,7 +204,8 @@ public class Movecraft extends JavaPlugin {
 				disableShadow(typ);
 			}
 		}
-		
+		Settings.ExchangeDispensersForChests = getConfig().getBoolean("ExchangeDispensersForChests", false);
+
 		//load the sieges.yml file
 		File siegesFile = new File( Movecraft.getInstance().getDataFolder().getAbsolutePath() + "/sieges.yml" );
 		InputStream input=null;

--- a/src/main/java/net/countercraft/movecraft/async/detection/DetectionTaskData.java
+++ b/src/main/java/net/countercraft/movecraft/async/detection/DetectionTaskData.java
@@ -81,7 +81,11 @@ public class DetectionTaskData {
 	}
 
 	void setFailMessage( String failMessage ) {
-		this.failMessage = failMessage;
+		if (this.failMessage == null) {
+			this.failMessage = failMessage;
+		} else {
+			this.failMessage += '\n' + failMessage;
+		}
 	}
 
 	public MovecraftLocation[] getBlockList() {

--- a/src/main/java/net/countercraft/movecraft/config/Settings.java
+++ b/src/main/java/net/countercraft/movecraft/config/Settings.java
@@ -86,4 +86,5 @@ public class Settings {
 	public static HashSet<Integer> AssaultDestroyableBlocks;
 	public static int AssaultDamagesPerBlock;
 	public static HashSet<Integer> DisableShadowBlocks;
+	public static boolean ExchangeDispensersForChests;
 }


### PR DESCRIPTION
This patch allows to automatically extend the upper limit for chests and trapped chests, adding one extra chest for every three dispensers not used (but allowed) on the craft.

No other block limit is changed (including the craft size) and it won't affect any of the current crafts (but allows to manually remove dispensers and replace them with chests).

Additionally, **the detection process now gives more information** when a fly block limit is not met (not only percentages but also block counts and craft size). It also reports all the violations found (not only the first one). Examples:

    Not enough flyblock: redstone block -> 9 < 10 (1,00% of 1000)

or

    Too much flyblock: chest -> 31 > 29 (3,00% of 999) + 1 extra (in exchange for 3 dispensers)
    Not enough flyblock: redstone block -> 8 < 9 (1,00% of 999)

This feature is controlled by the config entry `ExchangeDispensersForChests` which is `false` by default (for backward compatibility).