### PR TITLE
Fix redstone randomly triggering cannons.

### DIFF
--- a/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -45,6 +45,7 @@ import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
+import org.bukkit.craftbukkit.v1_10_R1.block.CraftBlockState;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -1511,7 +1512,7 @@ public class AsyncManager extends BukkitRunnable {
         			s.setLine(2, "Damage:"+Movecraft.getInstance().assaultDamages.get(assault));
         			Calendar rightNow = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         			s.setLine(3, "Owner:"+executor.getRegionOwnerList(tRegion));
-        			s.update();
+					((CraftBlockState)s).update(false, false);
                     ProtectedRegion aRegion = Movecraft.getInstance().getWorldGuardPlugin().getRegionManager(w).getRegion(assault);
         			tRegion.getOwners().clear();
 					assaultI.remove();

--- a/src/main/java/net/countercraft/movecraft/listener/InteractListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/InteractListener.java
@@ -36,6 +36,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
+import org.bukkit.craftbukkit.v1_10_R1.block.CraftBlockState;
 import org.bukkit.craftbukkit.v1_10_R1.util.CraftMagicNumbers;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -229,7 +230,7 @@ public class InteractListener implements Listener {
 								&& org.bukkit.ChatColor.stripColor(sign.getLine(3)).equals("")) {
 							sign.setLine(2, "_\\ /_");
 							sign.setLine(3, "/ \\");
-							sign.update();
+							((CraftBlockState)sign).update(false, false);
 						}
 
 						if (event.getPlayer().hasPermission("movecraft." + craftTypeStr + ".pilot")
@@ -397,7 +398,7 @@ public class InteractListener implements Listener {
 				if (org.bukkit.ChatColor.stripColor(sign.getLine(2)).equals("") && sign.getLine(3).equals("")) {
 					sign.setLine(2, "_\\ /_");
 					sign.setLine(3, "/ \\");
-					sign.update();
+					((CraftBlockState)sign).update(false, false);
 				}
 
 				if (event.getPlayer().hasPermission("movecraft." + craftTypeStr + ".pilot")

--- a/src/main/java/net/countercraft/movecraft/utils/MapUpdateManager.java
+++ b/src/main/java/net/countercraft/movecraft/utils/MapUpdateManager.java
@@ -58,6 +58,8 @@ import org.bukkit.block.CommandBlock;
 import org.bukkit.block.Dispenser;
 import org.bukkit.craftbukkit.v1_10_R1.CraftChunk;
 import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_10_R1.block.CraftBlock;
+import org.bukkit.craftbukkit.v1_10_R1.block.CraftBlockState;
 import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_10_R1.util.CraftMagicNumbers;
 import org.bukkit.entity.Entity;
@@ -467,7 +469,7 @@ public class MapUpdateManager extends BukkitRunnable {
 									for(int line=0; line<((SignBlock)i.getWorldEditBaseBlock()).getText().length; line++) {
 										s.setLine( line, ((SignBlock)i.getWorldEditBaseBlock()).getText()[line] );
 									}
-									s.update();										
+									((CraftBlockState)s).update(false, false);
 								}								
 							}
 						} else {
@@ -482,7 +484,7 @@ public class MapUpdateManager extends BukkitRunnable {
 					}
 					if(madeChanges) { // send map updates to clients, and perform various checks
 						Location loc=new Location(w,i.getNewBlockLocation().getX(),i.getNewBlockLocation().getY(),i.getNewBlockLocation().getZ());
-						w.getBlockAt(loc).getState().update();
+						((CraftBlockState)w.getBlockAt(loc).getState()).update(false, false);
 					}
 				}
 				
@@ -596,7 +598,7 @@ public class MapUpdateManager extends BukkitRunnable {
 						p.sendBlockChange(sign.getLocation(), sign.getTypeId(), sign.getRawData());
 					}
 			}
-			sign.update();
+			((CraftBlockState)sign).update(false, false);
 		}
 	}
 


### PR DESCRIPTION
This use `CraftBlockState.update(boolean force, boolean applyPhysics)` instead of `CraftBlockState.update()` for every update, to ensure no physics are applied on blocks updates.