### PR TITLE
Fixed cruise direction when not specified.

### DIFF
--- a/src/main/java/net/countercraft/movecraft/listener/CommandListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/CommandListener.java
@@ -289,22 +289,24 @@ public class CommandListener implements CommandExecutor {
 			if ( player.hasPermission( "movecraft." + craft.getType().getCraftName() + ".move" ) ) {
 				if(craft.getType().getCanCruise()) {
 					if(args.length == 0) {
-						float yaw = player.getLocation().getYaw();
-						if(yaw >= 135 || yaw < -135) {
-							// north
-							craft.setCruiseDirection((byte)0x3);
-							craft.setCruising(true);
-						} else if(yaw >= 45) {
+						// Normalize yaw from [-360, 360] to [0, 360]
+						float yaw = (player.getLocation().getYaw() + 360.0f);
+						if (yaw >= 360.0f) yaw -= 360.0f;
+						if (yaw >= 45 && yaw < 135) {
 							// west
 							craft.setCruiseDirection((byte)0x5);
 							craft.setCruising(true);
-						} else if(yaw < -45) {
-							// south
-							craft.setCruiseDirection((byte)0x2);
+						} else if (yaw >= 135 && yaw < 225) {
+							// north
+							craft.setCruiseDirection((byte)0x3);
 							craft.setCruising(true);
-						} else {
+						} else if (yaw >= 225 && yaw <= 315){
 							// east
 							craft.setCruiseDirection((byte)0x4);
+							craft.setCruising(true);
+						} else {
+							// south
+							craft.setCruiseDirection((byte)0x2);
 							craft.setCruising(true);
 						}
 						return true;


### PR DESCRIPTION
`/cruise` sometimes choose the wrong direction because it assumes yaw is expressed between -180 and 180 when in fact is between -360 and 360.